### PR TITLE
Move settings management to Rust

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = [ "dialog-message", "path-all", "fs-create-dir", "fs-write-file", "fs-read-file", "shell-open"] }
+tauri = { version = "1.4", features = [ "dialog-message", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/src-tauri/i18n.json
+++ b/src-tauri/i18n.json
@@ -2,7 +2,8 @@
     "en-US": {
         "name": "English",
         "ok": "OK",
-        "saved-servers-write-failed": "We couldn't save the server list to your computer for the following reason:",
+        "saved-servers-write-failed": "We couldn't save your server list to your computer for the following reason:",
+        "settings-write-failed": "We couldn't save your settings to your computer for the following reason:",
         "tab-name-saved-servers": "My Servers",
         "tab-name-settings": "Settings",
         "saved-servers-scam-warning": "<b>Never join a server that includes paid items.</b> It's a scam! Look for another server where you can earn everything for free.",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,22 +16,6 @@
       "dialog": {
         "message": true
       },
-      "fs": {
-        "readFile": true,
-        "writeFile": true,
-        "createDir": true,
-        "scope": [
-          "$APPDATA/**",
-          "$APPDATA/*",
-          "$APPDATA",
-          "$RESOURCE/**",
-          "$RESOURCE/*",
-          "$RESOURCE"
-        ]
-      },
-      "path": {
-        "all": true
-      },
       "shell": {
         "all": false,
         "open": true

--- a/src/main.js
+++ b/src/main.js
@@ -85,7 +85,7 @@ async function initLanguageSelector(languageSelector) {
   }
 
   languageSelector.addEventListener('change', async (event) => {
-    await try_or_show_err_dialog(invoke('set_language', event.target.value), SETTINGS_WRITE_FAILED_I18N_KEY)
+    await try_or_show_err_dialog(invoke('set_language', { newLanguageId: event.target.value }), SETTINGS_WRITE_FAILED_I18N_KEY)
     await loadI18n(document)
   })
 }
@@ -231,7 +231,7 @@ async function buildSavedServerElement(savedServersElm, savedServer, isEditing) 
 }
 
 async function loadSavedServers() {
-  let savedServers = await try_or_show_err_dialog(invoke('load_saved_servers'), SAVED_SERVER_WRITE_FAILED_I18N_KEY)
+  let savedServers = await invoke('load_saved_servers')
   const savedServersElm = document.getElementById(SAVED_SERVERS_LIST_ID)
   for (const savedServer of savedServers) {
     savedServersElm.append(await buildSavedServerElement(savedServersElm, savedServer, false))

--- a/src/main.js
+++ b/src/main.js
@@ -72,7 +72,10 @@ function initTabs() {
 // Internationalization
 async function initLanguageSelector(languageSelector) {
   const currentLangId = await invoke('current_language_id')
-  for (const [langId, langName] of await invoke('all_language_ids_names')) {
+  const languages = await invoke('all_language_ids_names')
+  languages.sort(([, name1], [, name2]) => name1.localeCompare(name2))
+
+  for (const [langId, langName] of languages) {
     const option = document.createElement('option')
     option.textContent = langName
     option.value = langId


### PR DESCRIPTION
Follow-up to #1 that moves settings and language management from JS to Rust. Fixes an issue where the error dialog would no longer appear when servers/settings could not be written to disk.