### PR TITLE
Implement "add client" functionality

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
 regex = "1.10.4"
-tauri = { version = "1.4", features = [ "dialog-message", "shell-open"] }
+tauri = { version = "1.4", features = [ "dialog-open", "dialog-message", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/src-tauri/i18n.json
+++ b/src-tauri/i18n.json
@@ -13,6 +13,14 @@
         "saved-servers-play": "Play",
         "saved-servers-remove": "Remove",
         "saved-servers-udp-endpoint-label": "UDP Endpoint",
-        "saved-servers-https-endpoint-label": "HTTPS Endpoint"
+        "saved-servers-https-endpoint-label": "HTTPS Endpoint",
+        "settings-add-client-prompt": "<b>Before you play, add a 2014 Clone Wars Adventures client.</b> Because the client is the property of Daybreak Game Company, we can't distribute it, so you'll need to supply one. Please select <b>CloneWars.exe</b> from your filesystem using the file picker below.",
+        "settings-add-client-btn": "Add CloneWars.exe",
+        "settings-add-client-title": "Please select CloneWars.exe.",
+        "settings-add-client-executable-file-type-name": "Executable",
+        "settings-add-client-all-file-type-name": "All",
+        "settings-known-clients": "Clients you've added:",
+        "settings-add-client-error": "We couldn't add the client you selected for the following reason:",
+        "settings-added-client": "Successfully added the client with the following auto-detected version:"
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
     "allowlist": {
       "all": false,
       "dialog": {
-        "message": true
+        "message": true,
+        "open": true
       },
       "shell": {
         "all": false,

--- a/src/index.html
+++ b/src/index.html
@@ -23,7 +23,14 @@
         <button id="create-saved-server-btn" class="i18n" data-i18n-key="saved-servers-add-server-btn"></button>
         <ol id="saved-servers"></ol>
       </div>
-      <div class="tab-content" id="tab-content-settings">Settings</div>
+      <div class="tab-content" id="tab-content-settings">
+        <div class="i18n" data-i18n-key="settings-add-client-prompt"></div>
+        <button id="add-client-btn" class="i18n" data-i18n-key="settings-add-client-btn"></button>
+        <div id="known-clients-container">
+          <div id="known-clients-label" class="i18n" data-i18n-key="settings-known-clients"></div>
+          <ol id="client-list"></ol>
+        </div>
+      </div>
 
     </div>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -12,13 +12,13 @@
     <div class="container">
       <select id="language-selector" name="language-selector"></select>
       <div class="navigation">
-        <a class="tab tab-active i18n" id="tab-servers" data-i18n-key="tab-name-saved-servers"></a>
+        <a class="tab i18n" id="tab-servers" data-i18n-key="tab-name-saved-servers"></a>
         <a class="tab i18n" id="tab-settings" data-i18n-key="tab-name-settings"></a>
       </div>
 
       <div class="horizontal-divider"></div>
 
-      <div class="tab-content tab-content-active" id="tab-content-servers">
+      <div class="tab-content" id="tab-content-servers">
         <p class="i18n" data-i18n-key="saved-servers-scam-warning"></p>
         <button id="create-saved-server-btn" class="i18n" data-i18n-key="saved-servers-add-server-btn"></button>
         <ol id="saved-servers"></ol>

--- a/src/main.js
+++ b/src/main.js
@@ -320,28 +320,30 @@ async function initAddClientButton(buttonElement, listElement) {
       directory: false,
       filters: [
         { name: await getI18nValueForKey('settings-add-client-executable-file-type-name'), extensions: ["exe"]},
-        { name: await getI18nValueForKey('settings-add-client-all-file-type-name'), extensions: [""]}
+        { name: await getI18nValueForKey('settings-add-client-all-file-type-name'), extensions: ["*"]}
       ],
       multiple: false,
       title: await getI18nValueForKey('settings-add-client-title')
     })
 
-    const addClient = async () => {
-      const clientVersion = await invoke('add_client', {path: clientPath})
-      await refreshClientList(listElement)
-      message(
-        `${await getI18nValueForKey('settings-added-client')}\n${clientVersion}`,
-        {
-          okLabel: await getI18nValueForKey('ok'),
-          type: 'info'
-        }
+    if (clientPath) {
+      const addClient = async () => {
+        const clientVersion = await invoke('add_client', {path: clientPath})
+        await refreshClientList(listElement)
+        message(
+          `${await getI18nValueForKey('settings-added-client')}\n${clientVersion}`,
+          {
+            okLabel: await getI18nValueForKey('ok'),
+            type: 'info'
+          }
+        )
+      }
+
+      await try_or_show_err_dialog(
+        addClient(),
+        'settings-add-client-error'
       )
     }
-
-    await try_or_show_err_dialog(
-      addClient(),
-      'settings-add-client-error'
-    )
   })
 }
 
@@ -360,6 +362,8 @@ async function refreshClientList(element) {
     listItem.textContent = `${clientVersion} (${clientPath})`
     element.append(listItem)
   }
+
+  return clientList.length
 }
 
 async function main() {
@@ -376,7 +380,12 @@ async function main() {
 
   const clientList = document.getElementById('client-list')
   await initAddClientButton(document.getElementById('add-client-btn'), clientList)
-  await refreshClientList(clientList)
+
+  if (await refreshClientList(clientList) === 0) {
+    document.getElementById('tab-settings').click()
+  } else {
+    document.getElementById('tab-servers').click()
+  }
 }
 
 await main()

--- a/src/main.js
+++ b/src/main.js
@@ -353,9 +353,7 @@ async function refreshClientList(element) {
   }
 
   const clientList = await invoke('list_clients')
-  clientList.sort(([version1, ], [version2, ]) => {
-    version1.localeCompare(version2)
-  })
+  clientList.sort(([version1, ], [version2, ]) => version1.localeCompare(version2))
 
   for (const [clientVersion, clientPath] of clientList) {
     const listItem = document.createElement('li')

--- a/src/styles.css
+++ b/src/styles.css
@@ -115,7 +115,7 @@ p {
   margin-top: -1px;
 }
 
-#create-saved-server-btn {
+#create-saved-server-btn, #add-client-btn {
   background: var(--holo-bg-color-light);
   border: 1px solid var(--holo-bg-color);
   border-radius: 5px;
@@ -131,7 +131,7 @@ p {
   width: fit-content;
 }
 
-#create-saved-server-btn:hover {
+#create-saved-server-btn:hover, #add-client-btn:hover {
   background: var(--holo-bg);
 }
 
@@ -243,6 +243,15 @@ input, #saved-servers .saved-server-nickname-edit {
 
 .dragged {
   opacity: 50%;
+}
+
+#known-clients-label {
+  font-weight: 600;
+  margin-top: 15px;
+}
+
+#client-list {
+  list-style: square;
 }
 
 @font-face {


### PR DESCRIPTION
Implement "add client" functionality. Users can add multiple clients with different versions using a file picker. If they have not already added a client, users are prompted to add one on startup. Clients that no longer exist at the given location are removed from the Oxide client's list on startup.